### PR TITLE
Ensure assets are built again on master

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ async function run() {
     const prAssets = await getAssetSizes(files);
 
     await exec(`git checkout ${pullRequest.base.sha}`);
+    await buildAssets(buildAssetsCommand);
     const masterAssets = await getAssetSizes(files);
 
     const fileDiffs = diffSizes(normaliseFingerprint(masterAssets), normaliseFingerprint(prAssets));


### PR DESCRIPTION
This PR ensures that assets are built again on the head branch (master). Otherwise, the comparison doesn't do anything if a build step is required.